### PR TITLE
Fix falsexfalsebb.jpg Missing Thumbnails

### DIFF
--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -4442,17 +4442,10 @@ const app = new Vue({
       }, 200);
     },
     async getCurrentArtURL() {
-      //let artworkSize = 50;
-      //if (app.getThemeDirective("lcdArtworkSize") !== "") {
-      //  artworkSize = app.getThemeDirective("lcdArtworkSize");
-      //} else if (this.cfg.visual.directives.windowLayout === "twopanel") {
-      //  artworkSize = 110;
-      //}
       let artworkSize = app.getThemeDirective("lcdArtworkSize") > 0 ? app.getThemeDirective("lcdArtworkSize") : 256;
       if (this.cfg.visual.directives.windowLayout === "twopanel") {
         artworkSize = 110;
       }
-      //const mediaItem = (app?.mk?.nowPlayingItem?.attributes?.artwork?.url ? app?.mk?.nowPlayingItem : null) ?? (await this.mk.api.v3.music(`/v1/me/library/songs/${this.mk?.nowPlayingItem?.id}`)?.data?.data?.data[0]) ?? {};
       const mediaItem = (app?.mk?.nowPlayingItem?.attributes?.artwork?.url ? app.mk.nowPlayingItem : null) 
                         ?? (this.mk?.nowPlayingItem?.id ? (await this.mk.api.v3.music(`/v1/me/library/songs/${this.mk.nowPlayingItem.id}`))?.data?.data?.data?.[0] : null) 
                         ?? {};


### PR DESCRIPTION
Some thumbnails are missing due to incorrect artworkSize value in getCurrentArtURL() of vueapp.js

Close inspection of the network calls show that the correct image template was downloaded BUT replaced by 'false' instead of an integer.

<img width="1527" height="996" alt="Screenshot_20260225_201719" src="https://github.com/user-attachments/assets/a188cd1a-9799-4407-82f3-4953d2a361e9" />

Tracing the execution shows that in `src/renderer/main/vueapp.js` the getCurrentArtURL() calculates the artworkSize by calling `app.getThemeDirective("lcdArtworkSize")` which always returns false because cfg.forceDirectives.lcdArtworkSize is not defined.

<img width="1682" height="232" alt="Screenshot_20260225_222915" src="https://github.com/user-attachments/assets/5f82db9d-c0c3-49e5-8c1f-e8f10db85679" />

And because app.getThemeDirective("lcdArtworkSize") is only compared to empty string therefore any value returned (this case, false) will be the value of artworkSize.